### PR TITLE
fix: Assert that the comparison process depending of external node ap…

### DIFF
--- a/src/VisualDiff.php
+++ b/src/VisualDiff.php
@@ -137,5 +137,8 @@ class VisualDiff
         if ($process->isSuccessful()) {
             return rtrim($process->getOutput());
         }
+
+        $message = 'Could not run the Node process. Probably a missing NPM dependency.' . PHP_EOL . PHP_EOL;
+        throw new \RuntimeException($message . $process->getErrorOutput(), 1);
     }
 }


### PR DESCRIPTION
…plications executes OK.

Tests:

https://github.com/beyondcode/laravel-visual-diff/blob/fbf586f2a88671587c5d0a66def342e43333d7e2/src/VisualDiff.php#L133-L139

I'm not sure I can add tests, as I cannot replace Process here, it's being instatiated with `new` keyword,
I would go ahead and resolve it with container, but let's see what you have to say?

This would be equivalent
```php
$process = app()->make(Process::class, ['commandline' => $fullCommand]);
```
and then we could swap out in the test.

So, in manual testing...

When running `php artisan dusk`, and not `pngjs` installed

output is

```
PHPUnit 7.3.2 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 2.59 seconds, Memory: 14.00MB

There was 1 error:

1) Tests\Browser\ExampleTest::testBasicExample
RuntimeException: Could not run the Node process. Probably a missing NPM dependency.

module.js:557
    throw err;
    ^

Error: Cannot find module 'pngjs'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/bin/diff.js:1:73)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)


/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiff.php:144
/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiff.php:112
/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiffTester.php:150
/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiffTester.php:59
```

Then, next, without `pixelmatch` installed

```
PHPUnit 7.3.2 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 2.42 seconds, Memory: 14.00MB

There was 1 error:

1) Tests\Browser\ExampleTest::testBasicExample
RuntimeException: Could not run the Node process. Probably a missing NPM dependency.

module.js:557
    throw err;
    ^

Error: Cannot find module 'pixelmatch'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/bin/diff.js:3:13)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)


/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiff.php:144
/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiff.php:112
/Users/joaopatricio/code/packages/beyondcode/laravel-visual-diff/src/VisualDiffTester.php:150
```

Then, when both are installed...

```
PHPUnit 7.3.2 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 1.9 seconds, Memory: 14.00MB

OK (1 test, 1 assertion)
```


So, what do you think?
